### PR TITLE
New command 'project' and modify in 'config' command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -47,13 +47,6 @@ In error case:
 
 		if editConfig {
 			valueFile := map[string]interface{}{
-				"moldyPackageInfo": map[string]string{
-					"name":        terminal.BasicPrompt("Moldy Package Info > Name", "none"),
-					"version":     terminal.BasicPrompt("Moldy Package Info > Version", "none"),
-					"author":      terminal.BasicPrompt("Moldy Package Info > Author", "none"),
-					"description": terminal.BasicPrompt("Moldy Package Info > Description", "none"),
-					"url":         terminal.BasicPrompt("Moldy Package Info > URL", "none"),
-				},
 				"adminProjects": map[string]bool{
 					"gitInit":               terminal.BasicPrompt("Admin Projects > Git init", "true") == "true",
 					"conventionalCommits":   terminal.BasicPrompt("Admin Projects > Conventional Commits", "true") == "true",
@@ -67,7 +60,7 @@ In error case:
 					"colorsMode":  terminal.BasicPrompt("Aparience options > Colors mode", "true") == "true",
 				},
 				"moldyRunner": map[string]string{
-					"test": "echo 'Running a example command'",
+					"test": terminal.BasicPrompt("Moldy runner > Runner", "echo 'Running a example command'"),
 				},
 			}
 			paths := []string{

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -52,7 +52,7 @@ var projCmd = &cobra.Command{
 			lastDir := strings.Split(strings.Replace(dir, homeDir, "", 1), "/")
 			lastDir[1] = ""
 			lastDirStr := strings.Replace(strings.Join(lastDir, "/"), "/", "", 1)
-			file, err := os.Create(points + lastDirStr + "/test.toml")
+			file, err := os.Create(points + lastDirStr + "/Moldy.pkg.toml")
 
 			functions.CheckErrors(err, "1", "Something bad happened with the path", "Unknown exact solution. Leave please the issue in github.com/Moldy-Community/moldy")
 

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+
+	"github.com/Moldy-Community/moldy/core/terminal"
+	"github.com/Moldy-Community/moldy/utils/functions"
+	"github.com/pelletier/go-toml"
+	"github.com/spf13/cobra"
+)
+
+var (
+	initFlg bool
+)
+
+var projCmd = &cobra.Command{
+	Use:     "project",
+	Short:   "Init a project, make commits or change the configuration of moldy",
+	Long:    "Init a project with the flag --init\nMake commits in a easier way with the flag --commit\nChange the configuration of moldy with --config\n",
+	Aliases: []string{"proj", "prj"},
+	Example: "moldy project --init",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		if initFlg {
+			content := map[string]interface{}{
+				"moldyPackageInfo": map[string]string{
+					"name":        terminal.BasicPrompt("Moldy Package Info > Name", "none"),
+					"version":     terminal.BasicPrompt("Moldy Package Info > Version", "none"),
+					"author":      terminal.BasicPrompt("Moldy Package Info > Author", "none"),
+					"description": terminal.BasicPrompt("Moldy Package Info > Description", "none"),
+					"url":         terminal.BasicPrompt("Moldy Package Info > URL", "none"),
+				},
+			}
+
+			dir, _ := os.Getwd()
+			homeDir, _ := os.UserHomeDir()
+			points := ""
+			dirArr := strings.Split(strings.Replace(dir, "/", "", 1), "/")
+			homeDirArr := strings.Split(strings.Replace(homeDir, "/", "", 1), "/")
+
+			difference := len(dirArr) - len(homeDirArr)
+
+			for i := 1; i <= difference*2; i++ {
+				if i%3 == 0 {
+					points += "/"
+				} else {
+					points += "."
+				}
+			}
+
+			lastDir := strings.Split(strings.Replace(dir, homeDir, "", 1), "/")
+			lastDir[1] = ""
+			lastDirStr := strings.Replace(strings.Join(lastDir, "/"), "/", "", 1)
+			file, err := os.Create(points + lastDirStr + "/test.toml")
+
+			functions.CheckErrors(err, "1", "Something bad happened with the path", "Unknown exact solution. Leave please the issue in github.com/Moldy-Community/moldy")
+
+			err = toml.NewEncoder(file).Encode(content)
+
+			functions.CheckErrors(err, "1", "Something bad happened at the moment when the file was attempted to be created", "Unknown exact solution. Leave please the issue in github.com/Moldy-Community/moldy")
+
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(projCmd)
+	projCmd.Flags().BoolVarP(&initFlg, "init", "i", false, "Init a moldy project")
+}

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -34,12 +34,13 @@ var projCmd = &cobra.Command{
 			}
 
 			dir, _ := os.Getwd()
+			execDir, _ := os.Executable()
 			homeDir, _ := os.UserHomeDir()
 			points := ""
-			dirArr := strings.Split(strings.Replace(dir, "/", "", 1), "/")
+			execDirArr := strings.Split(strings.Replace(execDir, "/", "", 1), "/")
 			homeDirArr := strings.Split(strings.Replace(homeDir, "/", "", 1), "/")
 
-			difference := len(dirArr) - len(homeDirArr)
+			difference := len(execDirArr) - len(homeDirArr)
 
 			for i := 1; i <= difference*2; i++ {
 				if i%3 == 0 {
@@ -49,8 +50,17 @@ var projCmd = &cobra.Command{
 				}
 			}
 
+			pointsNeedAdd := len(strings.Split(points, "/")) * 2
+
+			for i := 0; i <= pointsNeedAdd; i++ {
+				if i%3 == 0 {
+					points += "/"
+				} else {
+					points += "."
+				}
+			}
+
 			lastDir := strings.Split(strings.Replace(dir, homeDir, "", 1), "/")
-			lastDir[1] = ""
 			lastDirStr := strings.Replace(strings.Join(lastDir, "/"), "/", "", 1)
 			file, err := os.Create(points + lastDirStr + "/Moldy.pkg.toml")
 

--- a/core/config/configFile.go
+++ b/core/config/configFile.go
@@ -10,13 +10,6 @@ import (
 /* Add the default values, paths, aliases and config name and type */
 var (
 	defaults = map[string]interface{}{
-		"moldyPackageInfo": map[string]string{
-			"name":        "none",
-			"version":     "none",
-			"author":      "Example Author",
-			"description": "Example description",
-			"url":         "https://github.com/exampleAuthor/examplePackage",
-		},
 		"adminProjects": map[string]bool{
 			"gitInit":               true,
 			"conventionalCommits":   true,

--- a/core/files/configMoldy/readConfig.go
+++ b/core/files/configMoldy/readConfig.go
@@ -20,22 +20,12 @@ type AparienceOptions struct {
 	ProgressBar bool
 }
 
-type MoldyPackageInfo struct {
-	Author      string
-	Description string
-	Name        string
-	Url         string
-	Version     string
-}
-
 type MoldyRunner struct {
 	Test string
 }
-
 type ConfigStruct struct {
 	AdminProjects    AdminProjects
 	AparienceOptions AparienceOptions
-	MoldyPackageInfo MoldyPackageInfo
 	MoldyRunner      MoldyRunner
 }
 


### PR DESCRIPTION
New command '**project**' that will be used when you start a project in moldy, creating a file with the name **Moldy.pkg.toml** in your actual folder. And the command '**config**' was updated in the content of the other file **MoldyFile.toml** and replaced this content to **Moldy.pkg.toml**